### PR TITLE
Update webgl-fundamentals.html

### DIFF
--- a/webgl/lessons/webgl-fundamentals.html
+++ b/webgl/lessons/webgl-fundamentals.html
@@ -249,7 +249,7 @@ The majority of the WebGL API is about setting up state to supply data to our GL
 In this case our only input to our GLSL program is <code>position</code> which is an attribute.
 The first thing we should do is look up the location of the attribute for the program
 we just created</p>
-<pre><code>var positionAttributeLocation = gl.getAttribLocation(program, &quot;position&quot;);
+<pre><code>var positionAttributeLocation = gl.getAttribLocation(program, &quot;a_position&quot;);
 </code></pre><p>Looking up attribute locations (and uniform locations) is something you should
 do during initialization, not in your render loop.</p>
 <p>Attributes get their data from buffers so we need to create a buffer</p>


### PR DESCRIPTION
changed
var positionAttributeLocation = gl.getAttribLocation(program, "position");
to
var positionAttributeLocation = gl.getAttribLocation(program, "a_position");

because a_position is used in shader
